### PR TITLE
fix: Fix missing }

### DIFF
--- a/zsh-exa.plugin.zsh
+++ b/zsh-exa.plugin.zsh
@@ -24,4 +24,6 @@ autoload -Uz .zsh-exa
   .zsh-exa; (( $? )) && {
     print "Error loading zsh-exa plugin, exit code: $?"
     exit 1
+  }
 }
+


### PR DESCRIPTION
This was causing an error:
/Users/joshka/.oh-my-zsh/custom/plugins/zsh-exa/zsh-exa.plugin.zsh:28: parse error near `\n'
