### PR TITLE
chore: use eza instead of exa

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -53,7 +53,7 @@
 *.fish     text eol=lf
 *.sh       text eol=lf
 *.zsh      text eol=lf
-functions/.zsh-exa text eol=lf
+functions/.zsh-eza text eol=lf
 # These are explicitly windows files and should use crlf
 *.bat      text eol=crlf
 *.cmd      text eol=crlf

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,7 +14,7 @@ repo:
   repo:
     host: github.com
     owner: zplugin
-    name: zsh-exa
+    name: zsh-eza
 actions:
   enabled:
     - git-blame-ignore-revs

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,13 @@
   <table style="width:100%;height:auto">
     <tr><td align="center">
   <h1>
-   <a title="❮ Zsh exa ❯" target="_self" href="https://github.com/z-shell/zsh-exa">
+   <a title="❮ Zsh eza ❯" target="_self" href="https://github.com/z-shell/zsh-eza">
   <img style="width:60px;height:60px"
     src="https://raw.githubusercontent.com/z-shell/zi/main/docs/images/logo.svg"
-    alt="Logo" /></a>❮ Zsh exa ❯
+    alt="Logo" /></a>❮ Zsh eza ❯
   </h1>
   <h2>
-  Zsh plugin which replace GNU/ls with <a target="_self" href="https://github.com/ogham/exa">ogham/exa</a>
+  Zsh plugin which replace GNU/ls with <a target="_self" href="https://github.com/eza-community/eza">eza-community/eza</a>
   </h2>
 <h3>
   <a href="https://github.com/orgs/z-shell/discussions/">《❔》Ask a Question </a>
@@ -18,10 +18,10 @@
 </h3></td></tr>
 <tr>
 <td align="center">
-  <a target="_self" href="https://github.com/zplugin/zsh-exa/actions/workflows/trunk-check.yml">
-    <img align="center" src="https://github.com/z-shell/zsh-exa/actions/workflows/trunk-check.yml/badge.svg?branch=main" alt="⭕ Trunk Check" />
+  <a target="_self" href="https://github.com/zplugin/zsh-eza/actions/workflows/trunk-check.yml">
+    <img align="center" src="https://github.com/z-shell/zsh-eza/actions/workflows/trunk-check.yml/badge.svg?branch=main" alt="⭕ Trunk Check" />
   </a>
-  <a target="_self" href="https://open.vscode.dev/z-shell/zsh-exa/">
+  <a target="_self" href="https://open.vscode.dev/z-shell/zsh-eza/">
     <img
       align="center"
       src="https://img.shields.io/badge/--007ACC?logo=visual%20studio%20code&logoColor=ffffff"
@@ -35,34 +35,34 @@
 
 ## Default settings
 
-Sets paramters and aliases for `exa` to replace `ls`, enable auto list directories on `cd` with `export AUTOCD=1`.
+Sets paramters and aliases for `eza` to replace `ls`, enable auto list directories on `cd` with `export AUTOCD=1`.
 
 ### Parameters
 
 ```shell
-exa_params=('--git' '--icons' '--classify' '--group-directories-first' '--time-style=long-iso' '--group' '--color-scale')
+eza_params=('--git' '--icons' '--classify' '--group-directories-first' '--time-style=long-iso' '--group' '--color-scale')
 ```
 
 ### Aliases
 
 ```shell
-alias ls='exa $exa_params'
-alias l='exa --git-ignore $exa_params'
-alias ll='exa --all --header --long $exa_params'
-alias llm='exa --all --header --long --sort=modified $exa_params'
-alias la='exa -lbhHigUmuSa'
-alias lx='exa -lbhHigUmuSa@'
-alias lt='exa --tree $exa_params'
-alias tree='exa --tree $exa_params'
+alias ls='eza $eza_params'
+alias l='eza --git-ignore $eza_params'
+alias ll='eza --all --header --long $eza_params'
+alias llm='eza --all --header --long --sort=modified $eza_params'
+alias la='eza -lbhHigUmuSa'
+alias lx='eza -lbhHigUmuSa@'
+alias lt='eza --tree $eza_params'
+alias tree='eza --tree $eza_params'
 ```
 
 ## Install
 
-The `exa` should be present to use this plugin. Install `exa` with Zi:
+The `eza` should be present to use this plugin. Install `eza` with Zi:
 
 ```shell
-zi ice from'gh-r' as'program' sbin'**/exa -> exa' atclone'cp -vf completions/exa.zsh _exa'
-zi light ogham/exa
+zi ice from'gh-r' as'program' sbin'**/eza -> eza' atclone'cp -vf completions/eza.zsh _eza'
+zi light eza-community/eza
 ```
 
 ### With [Zi](https://github.com/z-shell/zi)
@@ -70,43 +70,43 @@ zi light ogham/exa
 To install add to the `.zshrc` file:
 
 ```shell
-zi light zplugin/zsh-exa
+zi light zplugin/zsh-eza
 ```
 
-Install only if exa exists and enable auto list directories:
+Install only if eza exists and enable auto list directories:
 
 ```shell
-zi ice has'exa' atinit'AUTOCD=1'
-zi light zplugin/zsh-exa
+zi ice has'eza' atinit'AUTOCD=1'
+zi light zplugin/zsh-eza
 ```
 
-Install only if exa exists and enable auto list directories in turbo mode:
+Install only if eza exists and enable auto list directories in turbo mode:
 
 ```shell
-zi ice wait lucid has'exa' atinit'AUTOCD=1'
-zi light zplugin/zsh-exa
+zi ice wait lucid has'eza' atinit'AUTOCD=1'
+zi light zplugin/zsh-eza
 ```
 
-Install only if exa exists and enable auto list directories in turbo mode with the for syntax:
+Install only if eza exists and enable auto list directories in turbo mode with the for syntax:
 
 ```shell
 zi wait lucid for \
-  has'exa' atinit'AUTOCD=1' \
-    zplugin/zsh-exa
+  has'eza' atinit'AUTOCD=1' \
+    zplugin/zsh-eza
 ```
 
 ### With [Oh My Zsh](https://ohmyz.sh/)
 
-Clone the repository and add `zsh-exa` to the plugins array of your zshrc file:
+Clone the repository and add `zsh-eza` to the plugins array of your zshrc file:
 
 ```sh
 ~/.oh-my-zsh/custom/plugins
 ```
 
 ```sh
-plugins=(... zsh-exa)
+plugins=(... zsh-eza)
 ```
 
 ### With Zplug
 
-Add `zplug zplugin/zsh-exa` to your `~/.zshrc` and re-open your terminal session.
+Add `zplug zplugin/zsh-eza` to your `~/.zshrc` and re-open your terminal session.

--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -10,32 +10,32 @@ fi
 builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
 builtin setopt extended_glob warn_create_global typeset_silent
 
-if (( $+commands[exa] )); then
+if (( $+commands[eza] )); then
   typeset enable_autocd=0
-  typeset -ag exa_params
+  typeset -ag eza_params
 
-  exa_params=(
+  eza_params=(
     '--git' '--icons' '--classify' '--group'
     '--group-directories-first' '--time-style=long-iso' '--color-scale'
   )
 
-  alias ls='exa $exa_params'
-  alias l='exa --git-ignore $exa_params'
-  alias ll='exa --all --header --long $exa_params'
-  alias llm='exa --all --header --long --sort=modified $exa_params'
-  alias la='exa -lbhHigUmuSa'
-  alias lx='exa -lbhHigUmuSa@'
-  alias lt='exa --tree $exa_params'
-  alias tree='exa --tree $exa_params'
+  alias ls='eza $eza_params'
+  alias l='eza --git-ignore $eza_params'
+  alias ll='eza --all --header --long $eza_params'
+  alias llm='eza --all --header --long --sort=modified $eza_params'
+  alias la='eza -lbhHigUmuSa'
+  alias lx='eza -lbhHigUmuSa@'
+  alias lt='eza --tree $eza_params'
+  alias tree='eza --tree $eza_params'
 
   [[ "$AUTOCD" = <-> ]] && enable_autocd="$AUTOCD"
   if [[ "$enable_autocd" == "1" ]]; then
     # Function for cd auto list directories
-    →auto-exa() { command exa $exa_params; }
-    [[ $chpwd_functions[(r)→auto-exa] == →auto-exa ]] || chpwd_functions=( →auto-exa $chpwd_functions )
+    →auto-eza() { command eza $eza_params; }
+    [[ $chpwd_functions[(r)→auto-eza] == →auto-eza ]] || chpwd_functions=( →auto-eza $chpwd_functions )
   fi
 else
-  print "Please install exa before using this plugin." >&2
+  print "Please install eza before using this plugin." >&2
   return 1
 fi
 

--- a/zsh-eza.plugin.zsh
+++ b/zsh-eza.plugin.zsh
@@ -10,19 +10,19 @@
 
 # https://wiki.zshell.dev/community/zsh_plugin_standard#standard-plugins-hash
 typeset -gA Plugins
-Plugins[ZSH_EXA]="${0:h}"
+Plugins[ZSH_EZA]="${0:h}"
 
 # https://wiki.zshell.dev/community/zsh_plugin_standard#funtions-directory
 if [[ $PMSPEC != *f* ]]; then
   fpath+=( "${0:h}/functions" )
 fi
 
-autoload -Uz .zsh-exa
+autoload -Uz .zsh-eza
 
 # Load plugin
-(( ${+functions[.zsh-exa]} )) && {
-  .zsh-exa; (( $? )) && {
-    print "Error loading zsh-exa plugin, exit code: $?"
+(( ${+functions[.zsh-eza]} )) && {
+  .zsh-eza; (( $? )) && {
+    print "Error loading zsh-eza plugin, exit code: $?"
     exit 1
   }
 }


### PR DESCRIPTION
Exa is deprecated and replaced with eza. See https://github.com/ogham/exa/issues/1243

I'm not sure what the process for landing this is. My guess is that it's forking this repo to a new zsh-eza repo and merging the PR there.

It might also be useful for those migrating to support both exa and eza in this repo, rather than just one. I'm not familiar enough with zi however to know the process (I use omz).