### PR TITLE
Allow eza_params to be overwritten

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,15 +33,12 @@
 <tr><td><img align="center" style="width:100%;height:auto" src="https://user-images.githubusercontent.com/59910950/165784269-3a8a8bfe-f291-4a33-aac9-1afa2b7b767f.png" />
 </td></tr></table></div>
 
-## Default settings
+### Environment variables
 
-Sets paramters and aliases for `eza` to replace `ls`, enable auto list directories on `cd` with `export AUTOCD=1`.
-
-### Parameters
-
-```shell
-eza_params=('--git' '--icons' '--classify' '--group-directories-first' '--time-style=long-iso' '--group' '--color-scale')
-```
+| Variable | Description | Default |
+| ------------- | -------------- | -------------- |
+| _EZA_PARAMS | eza params to be used | `('--git' '--group' '--group-directories-first' '--time-style=long-iso' '--color-scale=all' '--icons')` |
+| AUTOCD | enable auto list directories on `cd` | 0 |
 
 ### Aliases
 

--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -10,14 +10,17 @@ fi
 builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
 builtin setopt extended_glob warn_create_global typeset_silent
 
+
 if (( $+commands[eza] )); then
   typeset enable_autocd=0
   typeset -ag eza_params
 
   eza_params=(
-    '--git' '--icons' '--group' '--group-directories-first'
-    '--time-style=long-iso' '--color-scale=all'
+    '--git' '--group' '--group-directories-first'
+    '--time-style=long-iso' '--color-scale=all' '--icons'
   )
+
+  [[ ! -z $_EZA_PARAMS ]] && eza_params=($_EZA_PARAMS)
 
   alias ls='eza $eza_params'
   alias l='eza --git-ignore $eza_params'

--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -10,14 +10,13 @@ fi
 builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
 builtin setopt extended_glob warn_create_global typeset_silent
 
-
 if (( $+commands[eza] )); then
   typeset enable_autocd=0
   typeset -ag eza_params
 
   eza_params=(
-    '--git' '--group' '--group-directories-first'
-    '--time-style=long-iso' '--color-scale=all' '--icons'
+    '--git' '--icons' '--group' '--group-directories-first'
+    '--time-style=long-iso' '--color-scale=all'
   )
 
   [[ ! -z $_EZA_PARAMS ]] && eza_params=($_EZA_PARAMS)


### PR DESCRIPTION
Allow `eza_params` to be overwritten by acting on `_EZA_PARAMS` env variable