### PR TITLE
Adjust error handling to keep zsh session alive

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,37 +1,6 @@
-<div align="center">
-  <table style="width:100%;height:auto">
-    <tr><td align="center">
-  <h1>
-   <a title="❮ Zsh eza ❯" target="_self" href="https://github.com/z-shell/zsh-eza">
-  <img style="width:60px;height:60px"
-    src="https://raw.githubusercontent.com/z-shell/zi/main/docs/images/logo.svg"
-    alt="Logo" /></a>❮ Zsh eza ❯
-  </h1>
-  <h2>
-  Zsh plugin which replace GNU/ls with <a target="_self" href="https://github.com/eza-community/eza">eza-community/eza</a>
-  </h2>
-<h3>
-  <a href="https://github.com/orgs/z-shell/discussions/">《❔》Ask a Question </a>
-  <a href="https://wiki.zshell.dev/search/">《💡》Search Wiki </a>
-  <a href="https://github.com/z-shell/community/issues/new?assignees=&labels=%F0%9F%91%A5+member&template=membership.yml&title=team%3A+">《💜》Join </a>
-  <a href="https://digitalclouds.crowdin.com/z-shell/">《🌐》Localize </a>
-</h3></td></tr>
-<tr>
-<td align="center">
-  <a target="_self" href="https://github.com/z-shell/zsh-eza/actions/workflows/trunk-check.yml">
-    <img align="center" src="https://github.com/z-shell/zsh-eza/actions/workflows/trunk-check.yml/badge.svg?branch=main" alt="⭕ Trunk Check" />
-  </a>
-  <a target="_self" href="https://open.vscode.dev/z-shell/zsh-eza/">
-    <img
-      align="center"
-      src="https://img.shields.io/badge/--007ACC?logo=visual%20studio%20code&logoColor=ffffff"
-      alt="Visual Studio Code"
-    />
-  </a>
-</td>
-</tr>
-<tr><td><img align="center" style="width:100%;height:auto" src="https://user-images.githubusercontent.com/59910950/165784269-3a8a8bfe-f291-4a33-aac9-1afa2b7b767f.png" />
-</td></tr></table></div>
+# 📂 zsh-eza
+
+a zsh plugin which replaces GNU/ls with <a target="_self" href="https://github.com/eza-community/eza">eza-community/eza</a>
 
 ### Environment variables
 
@@ -55,55 +24,44 @@ alias tree='eza --tree $eza_params'
 
 ## Install
 
-The `eza` should be present to use this plugin. Install `eza` with Zi:
+`eza` should be present to use this plugin. Install `eza` with Cargo:
 
 ```shell
-zi ice from'gh-r' as'program' sbin'**/eza -> eza' atclone'cp -vf completions/eza.zsh _eza'
-zi light eza-community/eza
+cargo install eza
 ```
+
+or your package manager of choice.
 
 ### With [Zi](https://github.com/z-shell/zi)
 
-To install add to the `.zshrc` file:
+Add the following to your `~/.zshrc`
 
 ```shell
-zi light z-shell/zsh-eza
-```
-
-Install only if eza exists and enable auto list directories:
-
-```shell
-zi ice has'eza' atinit'AUTOCD=1'
-zi light z-shell/zsh-eza
-```
-
-Install only if eza exists and enable auto list directories in turbo mode:
-
-```shell
-zi ice wait lucid has'eza' atinit'AUTOCD=1'
-zi light z-shell/zsh-eza
-```
-
-Install only if eza exists and enable auto list directories in turbo mode with the for syntax:
-
-```shell
-zi wait lucid for \
-  has'eza' atinit'AUTOCD=1' \
-    z-shell/zsh-eza
+zi light givensuman/zsh-eza
 ```
 
 ### With [Oh My Zsh](https://ohmyz.sh/)
 
-Clone the repository and add `zsh-eza` to the plugins array of your zshrc file:
+Clone the repository
 
-```sh
-~/.oh-my-zsh/custom/plugins
+```shell
+git clone https://github.com/givensuman/zsh-eza \
+  ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-eza
 ```
 
+and add `zsh-eza` to the plugins array of your `~/.zshrc`
+
 ```sh
-plugins=(... zsh-eza)
+plugins=(
+  ... 
+  zsh-eza
+)
 ```
 
 ### With Zplug
 
-Add `zplug z-shell/zsh-eza` to your `~/.zshrc` and re-open your terminal session.
+Add the following to your `~/.zshrc`
+
+```shell
+zplug givensuman/zsh-eza
+```

--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -1,8 +1,3 @@
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-#
-# Copyright (c) 2022 Salvydas Lukosius
-
 if [[ $TERM == 'dumb' ]]; then
   print "Error loading zsh-eza: plugin used in a dumb terminal." >&2
   return 1

--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -4,6 +4,7 @@
 # Copyright (c) 2022 Salvydas Lukosius
 
 if [[ $TERM == 'dumb' ]]; then
+  print "Error loading zsh-eza: plugin used in a dumb terminal." >&2
   return 1
 fi
 
@@ -37,7 +38,7 @@ if (( $+commands[eza] )); then
     [[ $chpwd_functions[(r)→auto-eza] == →auto-eza ]] || chpwd_functions=( →auto-eza $chpwd_functions )
   fi
 else
-  print "Please install eza before using this plugin." >&2
+  print "Error loading zsh-eza: please install eza before using this plugin." >&2
   return 1
 fi
 

--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -1,6 +1,6 @@
 if [[ $TERM == 'dumb' ]]; then
   print "Error loading zsh-eza: plugin used in a dumb terminal." >&2
-  return 1
+  return
 fi
 
 builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
@@ -28,13 +28,11 @@ if (( $+commands[eza] )); then
 
   [[ "$AUTOCD" = <-> ]] && enable_autocd="$AUTOCD"
   if [[ "$enable_autocd" == "1" ]]; then
-    # Function for cd auto list directories
+    # Function to call eza when changing directory
     →auto-eza() { command eza $eza_params; }
     [[ $chpwd_functions[(r)→auto-eza] == →auto-eza ]] || chpwd_functions=( →auto-eza $chpwd_functions )
   fi
 else
-  print "Error loading zsh-eza: please install eza before using this plugin." >&2
-  return 1
+  print "Error loading zsh-eza: eza not found." >&2
+  return
 fi
-
-return 0

--- a/zsh-eza.plugin.zsh
+++ b/zsh-eza.plugin.zsh
@@ -15,8 +15,6 @@ autoload -Uz .zsh-eza
 
 # Load plugin
 (( ${+functions[.zsh-eza]} )) && {
-  .zsh-eza; (( $? )) && {
-    return # Ran into an error
-  }
+  .zsh-eza
 }
 

--- a/zsh-eza.plugin.zsh
+++ b/zsh-eza.plugin.zsh
@@ -22,8 +22,7 @@ autoload -Uz .zsh-eza
 # Load plugin
 (( ${+functions[.zsh-eza]} )) && {
   .zsh-eza; (( $? )) && {
-    print "Error loading zsh-eza plugin, exit code: $?"
-    exit 1
+    return
   }
 }
 

--- a/zsh-eza.plugin.zsh
+++ b/zsh-eza.plugin.zsh
@@ -1,9 +1,3 @@
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-#
-# Copyright (c) 2022 Salvydas Lukosius
-#
-# Zsh Plugin Standard
 # https://wiki.zshell.dev/community/zsh_plugin_standard#zero-handling
 0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
@@ -12,7 +6,7 @@
 typeset -gA Plugins
 Plugins[ZSH_EZA]="${0:h}"
 
-# https://wiki.zshell.dev/community/zsh_plugin_standard#funtions-directory
+# https://wiki.zshell.dev/community/zsh_plugin_standard#functions-directory
 if [[ $PMSPEC != *f* ]]; then
   fpath+=( "${0:h}/functions" )
 fi

--- a/zsh-eza.plugin.zsh
+++ b/zsh-eza.plugin.zsh
@@ -16,7 +16,7 @@ autoload -Uz .zsh-eza
 # Load plugin
 (( ${+functions[.zsh-eza]} )) && {
   .zsh-eza; (( $? )) && {
-    return
+    return # Ran into an error
   }
 }
 


### PR DESCRIPTION
Small changes to error handling that strips out `exit` calls to prevent zsh from being exited when an error is encountered.

Closes #28 