### PR TITLE
Set the .zsh-eza function to return 0 instead of 1 when terminal is dumb

### DIFF
--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -4,7 +4,8 @@
 # Copyright (c) 2022 Salvydas Lukosius
 
 if [[ $TERM == 'dumb' ]]; then
-  return 1
+  print "Dumb/non-tty terminal detected, skipping loading zsh-eza"
+  return 0
 fi
 
 builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}


### PR DESCRIPTION
When a TTY is not available, or otherwise $TERM is set to `dumb`, returning 1 can cause the calling application to assume actual failure, potentially interfering with regular function. Returning 0 may be a bit less clear about zsh-eza's failure, but it doesn't misrepresent the state of the shell otherwise.

Printing a message will still communicate that the shell did not load zsh-eza in those cases where the user is trying to figure out where the issue lies.

An example of this problem is XPipe, where it's background non-tty enabled session fails to load, as it believes ZSH is failing to start.