### PR TITLE
fix eza-community/eza installation failed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ alias tree='eza --tree $eza_params'
 The `eza` should be present to use this plugin. Install `eza` with Zi:
 
 ```shell
-zi ice from'gh-r' as'program' sbin'**/eza -> eza' atclone'cp -vf completions/eza.zsh _eza'
+zi ice from'gh' as'program' sbin'**/eza -> eza' atclone'CARGO_HOME=$ZPFX cargo install --path . && cp -vf completions/eza.zsh _eza'
 zi light eza-community/eza
 ```
 

--- a/functions/.zsh-eza
+++ b/functions/.zsh-eza
@@ -35,6 +35,7 @@ if (( $+commands[eza] )); then
   if [[ "$enable_autocd" == "1" ]]; then
     # Function for cd auto list directories
     →auto-eza() { command eza $eza_params; }
+    typeset -g chpwd_functions
     [[ $chpwd_functions[(r)→auto-eza] == →auto-eza ]] || chpwd_functions=( →auto-eza $chpwd_functions )
   fi
 else


### PR DESCRIPTION
#The original installation of 'eza-community/eza' is obsolete

![图片](https://github.com/user-attachments/assets/81550b0a-d2f7-4b33-a3e8-68759068ff35)


#New installation of 'eza-community/eza'
```shell:
zi ice from'gh' as'program' sbin'**/eza -> eza' atclone'CARGO_HOME=$ZPFX cargo install --path . && cp -vf completions/zsh/_eza _eza' 
zi light eza-community/eza

```